### PR TITLE
Clean up Python code

### DIFF
--- a/examples/operators/tests/python/testMultiplyBy.py
+++ b/examples/operators/tests/python/testMultiplyBy.py
@@ -8,40 +8,53 @@ import numpy as np
 
 class TestMultiplyByStandalone(unittest.TestCase):
     """Class for driving the test in standalone mode"""
+
     def setUp(self):
-        ''' Set up to run test as Standalone'''
+        """Set up to run test as Standalone"""
         Tester.setup_standalone(self)
+
     def _add_toolkits(self, topo):
-        ''' Add required toolkits for test to run '''
+        # Add required toolkits for test to run
         tk.add_toolkit(topo, '../../examples.operators')
         tk.add_toolkit(topo, '../examples.operators.testing')
+
     def test_op(self):
-        ''' Create topology to drive the test from com.ibm.streamsx.testing.spl '''
+        """ Test the operator using a test composite for data generation. """
         topo = Topology()
         self._add_toolkits(topo)
 
-        '''Set up parameter to call the test composite'''
-        params = {'factor':3}
+        # Set up parameter to call the test composite,
+        # in this case multiplying by three, the same
+        # factor is used in the conditions set up for the test
+        factor = 3
+        params = {'factor':factor}
 
-        ''' Call the test composite'''
-        test_op = op.Source(topo, 'examples.operators.testing::TestMultiplyBy', 'tuple<int32 result>', params=params)
+        # Call the test composite
+        test_op = op.Source(topo, 'examples.operators.testing::TestMultiplyBy',
+            'tuple<int32 result>', params=params)
 
-        ''' Convert the SPLStream to Python Stream so we can work with the data in the tester '''
-        mapped = test_op.stream.map(lambda x: x['result'])
-
-        ''' Set up Tester to validate the result of running the test composite'''
+        # Set up Tester to validate the result of running the test composite
         tester = Tester(topo)
 
-        ''' Example to check for tuple count'''
+        # Example to check for tuple count
         tester.tuple_count(test_op.stream, 34)
 
-        ''' Example to check content of the stream with an expected list of data'''
-        expected = list(np.arange(0, 100, 3))
+        # Example to check content of the stream with an expected list of data
+        # Use map to covert the SPL tuple with a single attribute into
+        # a stream of ints.
+        mapped = test_op.stream.map(lambda x: x['result'])
+        expected = list(np.arange(0, 100, factor))
         tester.contents(mapped, expected)
 
-        ''' Example to check data tuple by tuple'''
-        tester.tuple_check(test_op.stream, lambda  x:(x['result']%3)==0)
+        # Example to check data tuple by tuple
+        # The callable passed into tuple_check will be called
+        # for each tuple on the stream.
+        # If the callable returns False then the test will fail.
+        # The SPL tuple is passed in a dict with the keys being the
+        # attribute names
+        tester.tuple_check(test_op.stream, lambda x: x['result'] % factor == 0)
 
+        # Runs the test, a failure will cause an assertion to be raised
         tester.test(self.test_ctxtype, self.test_config)
 
 


### PR DESCRIPTION
Clean up the Python code to align it with PEP8.

Improved some comments.

Fixes #13